### PR TITLE
Prevent events from firing unless added

### DIFF
--- a/src/app/components/tableau/tableauViz.directive.js
+++ b/src/app/components/tableau/tableauViz.directive.js
@@ -25,7 +25,7 @@
         onToolbarStateChange: '&',
         onVizResize: '&'
       },
-      link: function (scope, element) {
+      link: function (scope, element, attrs) {
         var viz;
 
         scope.$watch('vizHeight', function (value) {
@@ -58,77 +58,77 @@
           viz = new tableau.api.Viz(element[0], scope.path, options);
 
           // Implement callbacks for each event if passed in.
-          if (scope.onCustomViewLoad) {
+          if (scope.onCustomViewLoad && angular.isDefined(attrs.onCustomViewLoad)) {
             viz.addEventListener('customViewLoad', function (events) {
               $log.log("Event 'customViewLoad' has fired");
               scope.onCustomViewLoad({ arg1: events });
             });
           }
 
-          if (scope.onCustomViewRemove) {
+          if (scope.onCustomViewRemove && angular.isDefined(attrs.onCustomViewRemove)) {
             viz.addEventListener('customViewRemove', function (events) {
               $log.log("Event 'customViewRemove' has fired");
               scope.onCustomViewRemove({ arg1: events });
             });
           }
 
-          if (scope.onCustomViewSave) {
+          if (scope.onCustomViewSave && angular.isDefined(attrs.onCustomViewSave)) {
             viz.addEventListener('customViewSave', function (events) {
               $log.log("Event 'customViewSave' has fired");
               scope.onCustomViewSave({ arg1: events });
             });
           }
 
-          if (scope.onCustomViewSetDefault) {
+          if (scope.onCustomViewSetDefault && angular.isDefined(attrs.onCustomViewSetDefault)) {
             viz.addEventListener('customViewSetDefault', function (events) {
               $log.log("Event 'customViewSetDefault' has fired");
               scope.onCustomViewSetDefault({ arg1: events });
             });
           }
           
-           if (scope.onFilterChange) {
+           if (scope.onFilterChange && angular.isDefined(attrs.onFilterChange)) {
             viz.addEventListener('filterChange', function (events) {
               $log.log("Event 'filterChange' has fired");
               scope.onFilterChange({ arg1: events });
             });
           }
 
-           if (scope.onMarksSelection) {
+           if (scope.onMarksSelection && angular.isDefined(attrs.onMarksSelection)) {
             viz.addEventListener('marksSelection', function (events) {
               $log.log("Event 'marksSelection' has fired");
               scope.onMarksSelection({ arg1: events });
             });
           }
 
-           if (scope.onParameterChange) {
-            viz.addEventListener('parameterValueChange', function (events) {
-              $log.log("Event 'parameterValueChange' has fired");
-              scope.onParameterChange({ arg1: events });
-            });
+           if (scope.onParameterChange && angular.isDefined(attrs.onParameterChange)) {
+              viz.addEventListener('parameterValueChange', function (events) {
+                $log.log("Event 'parameterValueChange' has fired");
+                scope.onParameterChange({ arg1: events });
+              });
           }
 
-          if (scope.onStoryPointSwitch) {
+          if (scope.onStoryPointSwitch && angular.isDefined(attrs.onStoryPointSwitch)) {
             viz.addEventListener('storyPointSwitch', function (events) {
               $log.log("Event 'storyPointSwitch' has fired");
               scope.onStoryPointSwitch({ arg1: events });
             });
           }
 
-          if (scope.onTabSwitch) {
+          if (scope.onTabSwitch && angular.isDefined(attrs.onTabSwitch)) {
             viz.addEventListener('tabSwitch', function (events) {
               $log.log("Event 'tabSwitch' has fired");
               scope.onTabSwitch({ arg1: events });
             });
           }
 
-          if (scope.onToolbarStateChange) {
+          if (scope.onToolbarStateChange && angular.isDefined(attrs.onToolbarStateChange)) {
             viz.addEventListener('toolbarStateChange', function (events) {
               $log.log("Event 'toolbarStateChange' has fired");
               scope.onToolbarStateChange({ arg1: events });
             });
           }
 
-          if (scope.onVizResize) {
+          if (scope.onVizResize && angular.isDefined(attrs.onVizResize)) {
             viz.addEventListener('vizResize', function (events) {
               $log.log("Event 'vizResize' has fired");
               scope.onVizResize({ arg1: events });


### PR DESCRIPTION
Events were firing even though they were not added to directive html code. This is now fixed.